### PR TITLE
Draw text limit

### DIFF
--- a/Include/ZL_Font.h
+++ b/Include/ZL_Font.h
@@ -201,6 +201,7 @@ struct ZL_Font
 
 	// Requests a limit of the number of bytes processed for the next call to GetWidth/GetHeight/GetDimensions/Draw/CreateBuffer
 	void RequestCharLimit(int limitCount);
+	void DrawCharLimit(int charLimit);
 
 	private: struct ZL_Font_Impl* impl;
 };

--- a/Source/ZL_Font.cpp
+++ b/Source/ZL_Font.cpp
@@ -182,11 +182,12 @@ struct ZL_FontBitmap_Impl : ZL_Font_Impl
 		vbox[1] = vbox[3] = y - lh*s(0.2); //bottom
 		vbox[0] = vbox[4] = x;             //left
 		int v = 0;
-		int charIndex = 0;
+		int charIndex = -1;
 		ZLGL_TEXCOORDPOINTER(2, GL_SCALAR, 0, texcoords);
 		ZLGL_VERTEXTPOINTER(2, GL_SCALAR, 0, vertices);
 		for (const unsigned char *p = (const unsigned char*)text, *pEnd = (limitCount ? p + limitCount : (unsigned char*)-1); *p && p < pEnd; p++)
 		{
+			++charIndex;
 			if (*p == '\r') continue;
 			if (*p == '\n') { vbox[4] = vbox[0] = x; vbox[7] = vbox[5] -= (lh + (scaleh * fLineSpacing)); vbox[1] = vbox[3] -= (lh + (scaleh * fLineSpacing)); continue; }
 			if (*p <= ' ') { vbox[4] = vbox[0] = vbox[0] + (scalew * fSpaceWidth) + cs; continue; }
@@ -204,7 +205,6 @@ struct ZL_FontBitmap_Impl : ZL_Font_Impl
 				v = 0;
 			}
 			vbox[4] = vbox[0] = vbox[2] + cs;
-			charIndex++;
 		}
 		if (v) glDrawArraysUnbuffered(GL_TRIANGLES, 0, 6*v);
 	}
@@ -226,9 +226,10 @@ struct ZL_FontBitmap_Impl : ZL_Font_Impl
 		vbox[0] = vbox[4] = 0;                   //left
 		width = 0;
 		int vv = 0;
-		int charIndex = 0;
+		int charIndex = -1;
 		for (const unsigned char *p = (const unsigned char*)text, *pEnd = (limitCount ? p + limitCount : (unsigned char*)-1); *p && p < pEnd; p++)
 		{
+			++charIndex;
 			if (*p == '\r') continue;
 			if (*p == '\n') { if (vbox[2] > width) width = vbox[2]; vbox[4] = vbox[0] = 0; vbox[7] = vbox[5] -= (fLineHeight + fLineSpacing); vbox[1] = vbox[3] -= (fLineHeight + fLineSpacing); continue; }
 			if (*p <= ' ') { vbox[4] = vbox[0] = vbox[0] + fSpaceWidth + fCharSpacing; continue; }
@@ -243,7 +244,6 @@ struct ZL_FontBitmap_Impl : ZL_Font_Impl
 			}
 			vbox[4] = vbox[0] = vbox[2] + fCharSpacing;
 			vv += 12;
-			charIndex++;
 		}
 		if (vbox[2] > width) width = vbox[2];
 		height = 0 - (vbox[1] - fLineHeight*s(0.8));
@@ -485,9 +485,10 @@ struct ZL_FontTTF_Impl : ZL_Font_Impl
 		unsigned char sz;
 		unsigned short cd;
 		width = 0;
-		int charIndex = 0;
+		int charIndex = -1;
 		for (const unsigned char *p = (const unsigned char*)text, *pEnd = (limitCount ? p + limitCount : (unsigned char*)-1); *p && p < pEnd; p += sz)
 		{
+			++charIndex;
 			if (*p == '\r') { sz = 1; continue; }
 			if (*p == '\n') { sz = 1; if (x - fCharSpacing + olr > width) width = x - fCharSpacing + olr; x = 0; y -= (fLineHeight + fLineSpacing); continue; }
 			if (*p <= ' ' ) { sz = 1; x += fSpaceWidth + fCharSpacing; continue; }
@@ -505,7 +506,6 @@ struct ZL_FontTTF_Impl : ZL_Font_Impl
 			vertices[vv+5] = vertices[vv+9] = vertices[vv+11] = y - c.offy;             //top
 			vertices[vv+1] = vertices[vv+3] = vertices[vv+ 7] = vertices[vv+5] - lh;    //bottom
 			x += c.advance + fCharSpacing;
-			charIndex++;
 		}
 		height = 0 - (y - fLineHeight);
 		if (x - fCharSpacing + olr > width) width = x - fCharSpacing + olr;
@@ -533,12 +533,13 @@ struct ZL_FontTTF_Impl : ZL_Font_Impl
 		ZLGL_VERTEXTPOINTER(2, GL_SCALAR, 0, vertices);
 		GLscalar cs = fCharSpacing, lh = (scaleh * (fLineHeight+(olt+olb)));
 		int v = 0;
-		int charIndex = 0;
+		int charIndex = -1;
 		signed char last_tex = -1;
 		unsigned char sz;
 		unsigned short cd;
 		for (const unsigned char *p = (const unsigned char*)text, *pEnd = (limitCount ? p + limitCount : (unsigned char*)-1); *p && p < pEnd; p += sz)
 		{
+			++charIndex;
 			if (*p == '\r') { sz = 1; continue; }
 			if (*p == '\n') { sz = 1; x = xleft; y -= ((fLineHeight+fLineSpacing)*scaleh); continue; }
 			if (*p <= ' ' ) { sz = 1; x += (fSpaceWidth + cs) * scalew; continue; }
@@ -564,7 +565,6 @@ struct ZL_FontTTF_Impl : ZL_Font_Impl
 			vertices[vv+1] = vertices[vv+3] = vertices[vv+ 7] = vertices[vv+5] - lh;               //bottom
 			if (v == VBSIZE) { glDrawArraysUnbuffered(GL_TRIANGLES, 0, 6*VBSIZE); v = 0; }
 			x += (c.advance + cs) * scalew;
-			charIndex++;
 		}
 		if (v) glDrawArraysUnbuffered(GL_TRIANGLES, 0, 6*v);
 	}

--- a/Source/ZL_Font.cpp
+++ b/Source/ZL_Font.cpp
@@ -194,12 +194,11 @@ struct ZL_FontBitmap_Impl : ZL_Font_Impl
 			unsigned char charidx = *p-' '-1;
 			if (charidx >= (sizeof(CharWidths)/sizeof(CharWidths[0])) || !CharWidths[charidx]) continue;
 			vbox[6] = vbox[2] = vbox[0] + (scalew * CharWidths[charidx]);
-			if (charLimit == -1 || charIndex < charLimit) {
-				memcpy(&texcoords[12 * v + 0], TextureCoordinates[*p - ' ' - 1] + 0, sizeof(texcoords[0]) * 6);
-				memcpy(&texcoords[12 * v + 6], TextureCoordinates[*p - ' ' - 1] + 2, sizeof(texcoords[0]) * 6);
-				memcpy(&vertices[12 * v + 0], vbox + 0, sizeof(texcoords[0]) * 6);
-				memcpy(&vertices[12 * v + 6], vbox + 2, sizeof(texcoords[0]) * 6);
-			}
+			unsigned char tc = (charLimit == -1 || charIndex < charLimit) ? (*p - ' ' - 1) : -1;
+			memcpy(&texcoords[12 * v + 0], TextureCoordinates[tc] + 0, sizeof(texcoords[0]) * 6);
+			memcpy(&texcoords[12 * v + 6], TextureCoordinates[tc] + 2, sizeof(texcoords[0]) * 6);
+			memcpy(&vertices[12 * v + 0], vbox + 0, sizeof(texcoords[0]) * 6);
+			memcpy(&vertices[12 * v + 6], vbox + 2, sizeof(texcoords[0]) * 6);
 			if (++v==VBSIZE) {
 				glDrawArraysUnbuffered(GL_TRIANGLES, 0, 6*VBSIZE);
 				v = 0;
@@ -236,12 +235,11 @@ struct ZL_FontBitmap_Impl : ZL_Font_Impl
 			unsigned char charidx = *p-' '-1;
 			if (charidx >= (sizeof(CharWidths)/sizeof(CharWidths[0])) || !CharWidths[charidx]) continue;
 			vbox[6] = vbox[2] = vbox[0] + CharWidths[charidx];
-			if (charLimit == -1 || charIndex < charLimit) {
-				memcpy(&texcoords[vv + 0], TextureCoordinates[*p - ' ' - 1] + 0, sizeof(texcoords[0]) * 6);
-				memcpy(&texcoords[vv + 6], TextureCoordinates[*p - ' ' - 1] + 2, sizeof(texcoords[0]) * 6);
-				memcpy(&vertices[vv + 0], vbox + 0, sizeof(vertices[0]) * 6);
-				memcpy(&vertices[vv + 6], vbox + 2, sizeof(vertices[0]) * 6);
-			}
+			unsigned char tc = (charLimit == -1 || charIndex < charLimit) ? (*p - ' ' - 1) : -1;
+			memcpy(&texcoords[vv + 0], TextureCoordinates[tc] + 0, sizeof(texcoords[0]) * 6);
+			memcpy(&texcoords[vv + 6], TextureCoordinates[tc] + 2, sizeof(texcoords[0]) * 6);
+			memcpy(&vertices[vv + 0], vbox + 0, sizeof(vertices[0]) * 6);
+			memcpy(&vertices[vv + 6], vbox + 2, sizeof(vertices[0]) * 6);
 			vbox[4] = vbox[0] = vbox[2] + fCharSpacing;
 			vv += 12;
 		}
@@ -497,10 +495,8 @@ struct ZL_FontTTF_Impl : ZL_Font_Impl
 			const Char& c = chars.Get(cd);
 			if (c.tex < 0) { x += fSpaceWidth + fCharSpacing; continue; }
 			int vv = 12 * (vecTTFTexLastIndex->operator[](c.tex)++);
-			if (charLimit == -1 || charIndex < charLimit) {
-				memcpy(&texcoords[vv+0], c.TextureCoordinates+0, sizeof(texcoords[0])*6);
-				memcpy(&texcoords[vv+6], c.TextureCoordinates+2, sizeof(texcoords[0])*6);
-			}
+			memcpy(&texcoords[vv+0], c.TextureCoordinates+0, sizeof(texcoords[0])*6);
+			memcpy(&texcoords[vv+6], c.TextureCoordinates+2, sizeof(texcoords[0])*6);
 			vertices[vv+0] = vertices[vv+4] = vertices[vv+ 8] = x + c.offx;             //left
 			vertices[vv+2] = vertices[vv+6] = vertices[vv+10] = vertices[vv] + c.width; //right
 			vertices[vv+5] = vertices[vv+9] = vertices[vv+11] = y - c.offy;             //top
@@ -555,10 +551,8 @@ struct ZL_FontTTF_Impl : ZL_Font_Impl
 				glBindTexture(GL_TEXTURE_2D, gltexids[last_tex]);
 			}
 			int vv = 12 * v++;
-			if (charLimit == -1 || charIndex < charLimit) {
-				memcpy(&texcoords[vv+0], c.TextureCoordinates+0, sizeof(texcoords[0])*6);
-				memcpy(&texcoords[vv+6], c.TextureCoordinates+2, sizeof(texcoords[0])*6);
-			}
+			memcpy(&texcoords[vv+0], c.TextureCoordinates+0, sizeof(texcoords[0])*6);
+			memcpy(&texcoords[vv+6], c.TextureCoordinates+2, sizeof(texcoords[0])*6);
 			vertices[vv+0] = vertices[vv+4] = vertices[vv+ 8] = x + (c.offx*scalew);               //left
 			vertices[vv+2] = vertices[vv+6] = vertices[vv+10] = vertices[vv+0] + (c.width*scalew); //right
 			vertices[vv+5] = vertices[vv+9] = vertices[vv+11] = y - (c.offy*scaleh);               //top

--- a/Source/ZL_Font.cpp
+++ b/Source/ZL_Font.cpp
@@ -37,6 +37,7 @@ struct ZL_Font_Impl : ZL_Impl, ZL_Font_Impl_Settings
 {
 	scalar fCharSpacing, fLineSpacing, fLineHeight, fSpaceWidth;
 	int limitCount;
+	int charLimit;
 	bool draw_at_baseline;
 	ZL_Font_Impl(bool draw_at_baseline) : fCharSpacing(0), fLineSpacing(0), fLineHeight(0), fSpaceWidth(0), limitCount(0), draw_at_baseline(draw_at_baseline) { }
 	virtual ~ZL_Font_Impl() {}
@@ -736,6 +737,7 @@ void ZL_Font::Draw(const ZL_Vector &p, const char *text, scalar scalew, scalar s
 { if (impl) impl->Draw(p.x, p.y, text, scalew, scaleh, color, draw_at_origin); }
 
 void ZL_Font::RequestCharLimit(int limitCount) { impl->limitCount = limitCount; }
+void ZL_Font::DrawCharLimit(int charLimit) { impl->charLimit = charLimit; }
 
 /* alternative using parameter struct for 2 or more options instead of that many overloaded draw methods
 void Draw(const ZL_Vector &p, const char *text, scalar scale) const;


### PR DESCRIPTION
This PR adds a naive-approach `DrawCharLimit` which sets the renderable text limit, which preserves the line-wrapping. This is probably not the best approach, so any corrections would be appreciated :)

Before (using manual `substr` to slice the "visible text" before `CreateBuffer`, notice the words "anything" and "even" have an awkward wrapping behaviour:

```
    ZL_String printedText = text.substr(0, charIndex);
    fntMain.CreateBuffer(printedText, 180, true).Draw(20, 100, ZL_Origin::TopLeft);
```

![before](https://user-images.githubusercontent.com/668915/90306508-dc7af700-df08-11ea-9449-b08927e12536.gif)

After:

```
    fntMain.DrawCharLimit(charIndex);
    fntMain.CreateBuffer(text, 180, true).Draw(20, 100, ZL_Origin::TopLeft);
```

![after](https://user-images.githubusercontent.com/668915/90306522-092f0e80-df09-11ea-8fa1-5ab76467d2f7.gif)
